### PR TITLE
Makefile: Allow to specify extra cxxflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BIN_DIR=bin
 LIBS=-I$(ARACHNE)/include -I$(COREARBITER)/include  -L$(ARACHNE)/lib -lArachne  -L$(COREARBITER)/lib \
 	-lCoreArbiter -I$(PERFUTILS)/include $(PERFUTILS)/lib/libPerfUtils.a -lpcrecpp -pthread
 
-CXXFLAGS=-g -std=c++11 -O3 -Wall -Werror -Wformat=2 -Wextra -Wwrite-strings -Wno-unused-parameter -Wmissing-format-attribute -Wno-non-template-friend -Woverloaded-virtual -Wcast-qual -Wcast-align -Wconversion -fomit-frame-pointer
+CXXFLAGS=-g -std=c++11 -O3 -Wall -Werror -Wformat=2 -Wextra -Wwrite-strings -Wno-unused-parameter -Wmissing-format-attribute -Wno-non-template-friend -Woverloaded-virtual -Wcast-qual -Wcast-align -Wconversion -fomit-frame-pointer $(EXTRA_CXXFLAGS)
 
 ARBITER_BENCHMARK_BINS = CoreRequest_Noncontended CoreRequest_Noncontended_Latency CoreRequest_Contended_Timeout CoreRequest_Contended_Timeout_Latency CoreRequest_Contended CoreRequest_Contended_Latency
 UNIFIED_BENCHMARK_BINS = SyntheticWorkload ThreadCreationScalability VaryCoreIncreaseThreshold CoreAwareness UniformWorkload


### PR DESCRIPTION
The link errors about undefined references to symbols that involve
types in the std::__cxx11 namespace. It is useful to allow to specify
the extra cxxflags such as 'EXTRA_CXXFLAGS=-D_GLIBCXX_USE_CXX11_ABI=0'
to handle this sort of atempt to link together object files that were
compiled with different values for the _GLIBCXX_USE_CXX11_ABI macro.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>